### PR TITLE
fix: fix link to author's profile on a boosted toot

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusListItem.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusListItem.kt
@@ -247,7 +247,7 @@ private fun StatusContent(
         model = statusUiData.avatar,
         modifier = Modifier.size(statusAvatarSize),
         shape = AppTheme.shape.smallAvatar.copy(CornerSize(12.dp)),
-        onClick = { navigateToProfile(statusUiData.account) }
+        onClick = { navigateToProfile(statusUiData.actionable.account) }
       )
       WidthSpacer(value = 7.dp)
       Column(modifier = Modifier.align(Alignment.Top)) {


### PR DESCRIPTION
Sorry, my bad. Introduced this bug in #22 

Before this pr, clicking on the avatar of a boosted toot does not navigate to the author's profile; instead, it navigates to the profile of the user who boosted this toot.

Before #22, it is using actionable.account, which is correct.

<img width="1299" alt="Screenshot 2024-01-27 at 11 54 11 AM" src="https://github.com/whitescent/Mastify/assets/10359255/f14d18a1-7df6-4037-ae5e-a86b9845f942">
