### PR TITLE
fix: fix the drag handler of bottom sheet is expanded to status bar

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
@@ -85,7 +85,7 @@ fun PostVisibilitySheet(
       }
     },
     drawerState = drawerState,
-    windowInsetsType = WindowInsetsCompat.Type.displayCutout(),
+    windowInsetsType = WindowInsetsCompat.Type.statusBars(),
   )
 }
 

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/EmojiSheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/EmojiSheet.kt
@@ -167,6 +167,6 @@ fun EmojiSheet(
       }
     },
     drawerState = drawerState,
-    windowInsetsType = WindowInsetsCompat.Type.displayCutout()
+    windowInsetsType = WindowInsetsCompat.Type.statusBars()
   )
 }

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDropdownMenu.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDropdownMenu.kt
@@ -112,7 +112,7 @@ fun StatusActionDrawer(
       }
     },
     drawerState = drawerState,
-    windowInsetsType = WindowInsetsCompat.Type.displayCutout(),
+    windowInsetsType = WindowInsetsCompat.Type.statusBars(),
     modifier = modifier
   )
 }

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/poll/NewPollSheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/poll/NewPollSheet.kt
@@ -295,7 +295,7 @@ fun NewPollSheet(
       }
     },
     drawerState = deadlineDrawerState,
-    windowInsetsType = WindowInsetsCompat.Type.displayCutout(),
+    windowInsetsType = WindowInsetsCompat.Type.statusBars(),
   )
 }
 


### PR DESCRIPTION
On devices without notch / display cutout, the bottom sheet is expanded to status bar and makes user unable to touch the drag handle of the bottom sheet.

Before

https://github.com/whitescent/Mastify/assets/10359255/ad92230b-acc6-40f1-bffa-ef70c695c0be


After:
device with notch

![safe-inset-1](https://github.com/whitescent/Mastify/assets/10359255/8d490674-ad86-4ef6-8d5e-570d6165c1bf)

![safe-inset-2](https://github.com/whitescent/Mastify/assets/10359255/acd61f38-ce0a-4749-8736-0177f7761765)

device without notch
![safe-inset-3](https://github.com/whitescent/Mastify/assets/10359255/6c7fc6b6-c363-4327-affb-2484fbb0448c)

![safe-inset-4](https://github.com/whitescent/Mastify/assets/10359255/e21618ed-1d23-47ab-af4a-3c4bc3a28737)
