### PR TITLE
refactor: migrate PostVisibilitySheet to gm3 bottom sheet

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/screen/post/Post.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/screen/post/Post.kt
@@ -335,7 +335,6 @@ fun Post(
             scope.launch {
               keyboard?.hide()
               openVisibilitySheet = true
-              visibilitySheetState.expand()
             }
           }
         },

--- a/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
@@ -19,11 +19,16 @@ package com.github.whitescent.mastify.screen.post
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,58 +40,58 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.view.WindowInsetsCompat
 import com.github.whitescent.R
 import com.github.whitescent.mastify.data.model.ui.StatusUiData.Visibility
 import com.github.whitescent.mastify.ui.component.CenterRow
 import com.github.whitescent.mastify.ui.component.HeightSpacer
 import com.github.whitescent.mastify.ui.component.WidthSpacer
 import com.github.whitescent.mastify.ui.theme.AppTheme
-import com.microsoft.fluentui.tokenized.drawer.BottomDrawer
-import com.microsoft.fluentui.tokenized.drawer.DrawerState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostVisibilitySheet(
-  drawerState: DrawerState,
+  sheetState: SheetState,
   currentVisibility: Visibility,
   onVisibilityUpdated: (Visibility) -> Unit,
+  onDismissRequest: () -> Unit,
 ) {
-  BottomDrawer(
-    drawerContent = {
-      Column(Modifier.padding(vertical = 10.dp)) {
-        Text(
-          text = stringResource(id = R.string.change_post_visibility),
-          fontSize = 20.sp,
-          fontWeight = FontWeight.Bold,
-          modifier = Modifier.align(Alignment.CenterHorizontally),
-          color = AppTheme.colors.primaryContent,
-        )
-        HeightSpacer(value = 6.dp)
-        Text(
-          text = stringResource(id = R.string.visibility_description),
-          fontSize = 16.sp,
-          fontWeight = FontWeight.Bold,
-          modifier = Modifier
-            .align(Alignment.CenterHorizontally)
-            .padding(horizontal = 48.dp),
-          color = Color.Gray,
-        )
-        HeightSpacer(value = 6.dp)
-        Column(Modifier.padding(horizontal = 12.dp)) {
-          Visibility.entries.forEach {
-            PostVisibilityItem(
-              selected = it == currentVisibility,
-              visibility = it,
-              onClick = { onVisibilityUpdated(it) },
-            )
-            if (it != Visibility.entries.last()) HeightSpacer(value = 6.dp)
-          }
+  ModalBottomSheet(
+    onDismissRequest = onDismissRequest,
+    sheetState = sheetState,
+    windowInsets = WindowInsets.statusBars,
+    containerColor = AppTheme.colors.bottomSheetBackground,
+  ) {
+    Column(Modifier.padding(vertical = 10.dp)) {
+      Text(
+        text = stringResource(id = R.string.change_post_visibility),
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        color = AppTheme.colors.primaryContent,
+      )
+      HeightSpacer(value = 6.dp)
+      Text(
+        text = stringResource(id = R.string.visibility_description),
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+          .align(Alignment.CenterHorizontally)
+          .padding(horizontal = 48.dp),
+        color = Color.Gray,
+      )
+      HeightSpacer(value = 6.dp)
+      Column(Modifier.padding(horizontal = 12.dp)) {
+        Visibility.entries.forEach {
+          PostVisibilityItem(
+            selected = it == currentVisibility,
+            visibility = it,
+            onClick = { onVisibilityUpdated(it) },
+          )
+          if (it != Visibility.entries.last()) HeightSpacer(value = 6.dp)
         }
       }
-    },
-    drawerState = drawerState,
-    windowInsetsType = WindowInsetsCompat.Type.statusBars(),
-  )
+    }
+  }
 }
 
 @Composable


### PR DESCRIPTION
Fix #27

https://github.com/whitescent/Mastify/assets/10359255/3f31ac99-4e11-418d-b539-e891d26be23b



This pr is similar to previous implementation in #13 , but adds `skipPartiallyExpanded=true` to always fully expand the bottom sheet.

If this looks good to you, I will move the rest of bottom drawers to gm3 bottom sheet as well in a new pr.