### PR TITLE
fix: fix background color of a PNG avatar

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/CircleShapeImage.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/CircleShapeImage.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
@@ -37,12 +38,14 @@ fun CircleShapeAsyncImage(
   contentScale: ContentScale = ContentScale.Fit,
   alpha: Float = 1f,
   colorFilter: ColorFilter? = null,
-  onClick: (() -> Unit)? = null
+  onClick: (() -> Unit)? = null,
+  color: Color = AppTheme.colors.background
 ) {
   Surface(
     modifier = modifier,
     shape = shape,
-    border = border
+    border = border,
+    color = color
   ) {
     AsyncImage(
       model = model,


### PR DESCRIPTION
If the avatar is a PNG, the background color becomes `Surface`'s default color `MaterialTheme.colorScheme.surface`, which is light purple on my device.

This pr adds a default background color to CircleShapeAsyncImage.

# Before:
![before-1](https://github.com/whitescent/Mastify/assets/10359255/3a495455-cb86-43b1-bfe0-18ce838c82cc)
![before-2](https://github.com/whitescent/Mastify/assets/10359255/a07f05a7-b633-4c73-b905-954e51d30a12)
![before](https://github.com/whitescent/Mastify/assets/10359255/549119e7-4630-42ff-956d-479a98e7eaca)

# After:
![after-1](https://github.com/whitescent/Mastify/assets/10359255/be1c4d3b-3732-4f37-b915-8214b23dc996)
![after-2](https://github.com/whitescent/Mastify/assets/10359255/3589f826-d94e-4150-b2e6-8b0cb34f6c8b)
![after](https://github.com/whitescent/Mastify/assets/10359255/b997f58b-d605-4ac9-9a51-b3e4700c0a03)
