### PR TITLE
fix: fix background color of text selection toolbar

### DIFF
--- a/app/src/main/res/values-night/theme.xml
+++ b/app/src/main/res/values-night/theme.xml
@@ -17,7 +17,7 @@
   -->
 
 <resources>
-  <style name="Theme.Mastify" parent="android:Theme.Material.Light.NoActionBar">
+  <style name="Theme.Mastify" parent="android:Theme.Material.NoActionBar">
     <item name="android:windowBackground">@color/black</item>
   </style>
   <style name="Theme.Mastify.Splash" parent="Theme.SplashScreen">


### PR DESCRIPTION
Its background stays light even in dark mode.

| Before  | After |
| ------------- | ------------- |
| ![text-toolbar-before](https://github.com/whitescent/Mastify/assets/10359255/17563f99-4240-4000-b318-7f80b16f6aa3)  | ![text-toolbar-after](https://github.com/whitescent/Mastify/assets/10359255/797b8c1b-d3be-469b-85e2-0c38e29b9975)  |