### PR TITLE
fix: bottom sheet overlaps with navigation buttons

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/screen/post/PostVisibilitySheet.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -58,7 +58,7 @@ fun PostVisibilitySheet(
   ModalBottomSheet(
     onDismissRequest = onDismissRequest,
     sheetState = sheetState,
-    windowInsets = WindowInsets.statusBars,
+    windowInsets = WindowInsets.systemBars,
     containerColor = AppTheme.colors.bottomSheetBackground,
   ) {
     Column(Modifier.padding(vertical = 10.dp)) {

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/EmojiSheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/EmojiSheet.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -69,7 +69,7 @@ fun EmojiSheet(
   val lazyGridState = rememberLazyGridState()
   ModalBottomSheet(
     sheetState = sheetState,
-    windowInsets = WindowInsets.statusBars,
+    windowInsets = WindowInsets.systemBars,
     onDismissRequest = onDismissRequest,
     containerColor = AppTheme.colors.bottomSheetBackground
   ) {

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDropdownMenu.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDropdownMenu.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
@@ -98,7 +98,7 @@ fun StatusActionDrawer(
   }
   ModalBottomSheet(
     sheetState = sheetState,
-    windowInsets = WindowInsets.statusBars,
+    windowInsets = WindowInsets.systemBars,
     containerColor = AppTheme.colors.bottomSheetBackground,
     modifier = modifier,
     onDismissRequest = onDismissRequest

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/poll/NewPollSheet.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/poll/NewPollSheet.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -249,7 +249,7 @@ fun NewPollSheet(
       sheetState = deadlineSheetState,
       containerColor = AppTheme.colors.bottomSheetBackground,
       onDismissRequest = { openDeadlineSheet = false },
-      windowInsets = WindowInsets.statusBars
+      windowInsets = WindowInsets.systemBars
     ) {
       Column(Modifier.padding(vertical = 14.dp)) {
         CenterRow(Modifier.padding(horizontal = 14.dp)) {


### PR DESCRIPTION
Button Sheet overlaps with navigation buttons:

(Hope this fixes all the inset problems)

Before:
![Screenshot_20240211_230829](https://github.com/whitescent/Mastify/assets/10359255/22b0bdfa-7ab8-4943-ae5b-9aedf6a995fb)

After:
![Screenshot_20240211_231315](https://github.com/whitescent/Mastify/assets/10359255/041abc98-2e57-4394-99c5-58d0bdf9ffc1)
![Screenshot_20240211_231341](https://github.com/whitescent/Mastify/assets/10359255/c91c5aa5-3339-4cf0-9c45-aaac4e9b6cc4)
![Screenshot_20240211_231422](https://github.com/whitescent/Mastify/assets/10359255/dd68ef59-0521-4107-8293-f0f64da288f9)
