### PR TITLE
fix: #50 fixed date format

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/utils/FormatFactory.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/utils/FormatFactory.kt
@@ -35,9 +35,24 @@ object FormatFactory {
       .format(timestamp.toInstant().toEpochMilliseconds())
   }
   fun getTime(timestamp: String): String {
-    val formatter = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
-    return formatter.format(Date.from(timestamp.toInstant().toJavaInstant()))
+    val zonedDateTime: ZonedDateTime = ZonedDateTime.ofInstant(
+      Instant.ofEpochSecond(timestamp.toLong()), 
+      ZoneId.systemDefault()
+    )
+
+    val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+    val timeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+
+    val formattedDate = zonedDateTime.format(dateFormatter.withLocale(Locale.getDefault()))
+    val formattedTime = zonedDateTime.format(timeFormatter.withLocale(Locale.getDefault()))
+
+    val dateComponents = formattedDate.split("/")
+
+    val monthAndDay = "${dateComponents[0]}/${dateComponents[1]}"
+
+    return "$monthAndDay $formattedTime"
   }
+
   fun getPercentageString(value: Float): String {
     val percentInstance = NumberFormat.getPercentInstance()
     percentInstance.maximumFractionDigits = if (value > 0.01f) 0 else 2


### PR DESCRIPTION
This change addresses the issue where the year was being displayed, and some regions were having issues with the previous implementation. The new method uses the DateTimeFormatter and ZonedDateTime classes in Kotlin to provide a more flexible and locale-aware way to format dates and times.