### PR TITLE
refactor(ui): polish time format

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
 
   defaultConfig {
     applicationId = "com.github.whitescent.mastify"
-    minSdk = 21
+    minSdk = 24
     targetSdk = 34
     versionCode = 16
     versionName = "1.4.0-alpha"

--- a/app/src/main/java/com/github/whitescent/mastify/utils/FormatFactory.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/utils/FormatFactory.kt
@@ -17,10 +17,13 @@
 
 package com.github.whitescent.mastify.utils
 
+import android.icu.text.DateFormat
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toLocalDateTime
 import java.net.MalformedURLException
-import java.text.DateFormat
 import java.text.NumberFormat
 import java.util.Date
 import java.util.Locale
@@ -43,9 +46,19 @@ object FormatFactory {
     return "$username@$domain"
   }
   fun getLocalizedDateTime(timestamp: String): String {
-    return DateFormat.getDateInstance(DateFormat.DEFAULT, Locale.getDefault())
-      .format(timestamp.toInstant().toEpochMilliseconds())
+    val currentYear = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year
+    val targetYear = timestamp.toInstant().toLocalDateTime(TimeZone.currentSystemDefault()).year
+
+    val pattern = if (currentYear == targetYear) {
+      DateFormat.ABBR_MONTH_DAY
+    } else {
+      DateFormat.YEAR_ABBR_MONTH_DAY
+    }
+    val formatter = DateFormat.getPatternInstance(pattern, Locale.getDefault())
+    return formatter.format(Date.from(timestamp.toInstant().toJavaInstant()))
   }
+  // This function follows the locale format, not the system format (24 hour or 12 hour mode).
+  // If the system format is desired, use [android.text.format.DateFormat] (requires a Context).
   fun getTime(timestamp: String): String {
     val formatter = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
     return formatter.format(Date.from(timestamp.toInstant().toJavaInstant()))


### PR DESCRIPTION
Fix #50 

This pr also bumps min OS to N because of the API. This should cover 96.3% of devices.

|US|CN|
|--|--|
|![Screenshot_20240217_190635](https://github.com/whitescent/Mastify/assets/10359255/13b1beb4-fc28-405f-ba7f-61406141dba8)| ![Screenshot_20240217_190655](https://github.com/whitescent/Mastify/assets/10359255/7f5d6558-3066-43e0-814d-0c6a4fe1f90d)|
| ![Screenshot_20240217_191640](https://github.com/whitescent/Mastify/assets/10359255/0355e618-3a9e-4191-8aab-dcb93e575d24) |![Screenshot_20240217_191629](https://github.com/whitescent/Mastify/assets/10359255/107fcde2-051e-423f-af5d-3838b551debc) |



