### PR TITLE
fix(ui): show text surrounded by del tag

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
@@ -197,6 +197,8 @@ private fun AnnotatedString.Builder.renderElement(
 
     "br" -> renderText("\n", textStyle)
 
+    "del" -> renderText(element.text(), textStyle.copy(textDecoration = TextDecoration.LineThrough))
+
     "strong" -> renderText(element.text(), textStyle.copy(fontWeight = FontWeight.Bold))
 
     "code", "pre" -> renderText(element.text(), textStyle) // TODO Try highlighting rendering

--- a/app/src/test/java/com/github/whitescent/mastify/timeline/HtmlTextTest.kt
+++ b/app/src/test/java/com/github/whitescent/mastify/timeline/HtmlTextTest.kt
@@ -48,6 +48,14 @@ class HtmlTextTest {
   }
 
   @Test
+  fun `test del label parse`() {
+    val text = "<p><span>还是觉得某些群体在「非受众」的游戏内曲解角色和要求「增加与我们群体有关的内容」十分过分了。<br><br>玩家应该是去寻找适合自己群体的游戏，而不是对其它游戏说三道四吧。<br><br></span><del>没有？没有的话就自己做啊。</del></p>"
+    val document = Jsoup.parse(text)
+    val expected = "还是觉得某些群体在「非受众」的游戏内曲解角色和要求「增加与我们群体有关的内容」十分过分了。\n\n玩家应该是去寻找适合自己群体的游戏，而不是对其它游戏说三道四吧。\n\n没有？没有的话就自己做啊。"
+    assertEquals(expected, buildContentAnnotatedString(document).text)
+  }
+
+  @Test
   fun `test reply text`() {
     val text = "<p><a href=\"https://mastodon.ktachibana.party/@kt\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@kt@mastodon.ktachibana.party</a><span> 想用 KTT 了 他真可爱！</span></p>"
     val document = Jsoup.parse(text)
@@ -163,6 +171,8 @@ private fun AnnotatedString.Builder.renderElement(
     "br" -> renderText("\n")
 
     "code", "pre", "strong" -> renderText(element.text())
+
+    "del" -> renderText(element.text())
 
     "span", "p", "i", "em" -> {
       val prevNode = element.previousSibling()


### PR DESCRIPTION
Interesting to know some platforms support `del` tag. [post](https://elk.zone/nya.one/notes/9pxhht6rjijn094n)

Expected: (on Moshidon)
![Screenshot_20240219_232922](https://github.com/whitescent/Mastify/assets/10359255/f41c935e-0a79-4bf4-9547-bc7eb244a2f1)


|before|after|
|--|--|
|![Screenshot_20240219_232950](https://github.com/whitescent/Mastify/assets/10359255/c8137f44-dc9e-432b-a291-390261f88e17)|![Screenshot_20240219_232834](https://github.com/whitescent/Mastify/assets/10359255/96773d96-7ade-49fb-8d1b-0f71558b28b0)|