### PR TITLE
fix(ui): remove Text if there is no visible text

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/data/model/ui/StatusUiData.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/data/model/ui/StatusUiData.kt
@@ -26,6 +26,7 @@ import com.github.whitescent.mastify.network.model.status.Hashtag
 import com.github.whitescent.mastify.network.model.status.Mention
 import com.github.whitescent.mastify.network.model.status.Poll
 import com.github.whitescent.mastify.network.model.status.Status
+import com.github.whitescent.mastify.ui.component.buildPlainText
 import kotlinx.collections.immutable.ImmutableList
 import org.jsoup.Jsoup
 
@@ -69,6 +70,7 @@ data class StatusUiData(
 
   val parsedContent: String = buildHtmlText(Jsoup.parse(content)).text
   val isInReplyTo inline get() = inReplyToId != null
+  val hasVisibleText : Boolean = buildPlainText(content, isInReplyToSomeone).trim().isNotEmpty()
 
   val isInReplyToSomeone inline get() = mentions.size == 1 && isInReplyTo
 

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
@@ -141,6 +141,14 @@ fun HtmlText(
   )
 }
 
+fun buildPlainText(content: String, filterMentionText: Boolean): String =
+  buildContentAnnotatedString(
+    Jsoup.parse(content),
+    TextStyle.Default.toSpanStyle(),
+    TextStyle.Default,
+    filterMentionText,
+  ).toString()
+
 private fun buildContentAnnotatedString(
   document: Document,
   urlSpanStyle: SpanStyle,

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDetailCard.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusDetailCard.kt
@@ -198,7 +198,7 @@ fun StatusDetailCard(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.padding(top = 8.dp)
               ) {
-                if (status.content.isNotEmpty()) {
+                if (status.hasVisibleText) {
                   SelectionContainer {
                     HtmlText(
                       text = status.content,

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusListItem.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/status/StatusListItem.kt
@@ -86,6 +86,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toInstant
+import org.jsoup.Jsoup
 
 @Composable
 fun StatusListItem(
@@ -353,7 +354,7 @@ private fun StatusContent(
                   verticalArrangement = Arrangement.spacedBy(12.dp),
                   modifier = Modifier.padding(top = 6.dp)
                 ) {
-                  if (statusUiData.content.isNotEmpty()) {
+                  if (statusUiData.hasVisibleText) {
                     HtmlText(
                       text = statusUiData.content,
                       fontSize = (15.5).sp,


### PR DESCRIPTION
Mastodon just returns an empty string if the content is empty. But Misskey returns a `<p></p>` and this shows an empty `Text` on Post.

This pr hides Text if the post does not have any visible text.

|before |after |
|--|--|
| ![Screenshot_20240220_233919](https://github.com/whitescent/Mastify/assets/10359255/20346a7a-5f5d-4e8b-8818-233fe1603fc4)|![Screenshot_20240220_234012](https://github.com/whitescent/Mastify/assets/10359255/7dcfdddd-5fcd-4c28-8e7c-dd376f60caa4)|
|![Screenshot_20240220_233931](https://github.com/whitescent/Mastify/assets/10359255/03d40e4e-4949-4684-b6ec-8f5076845f1a)|![Screenshot_20240220_234026](https://github.com/whitescent/Mastify/assets/10359255/2e267f0d-add6-446f-9810-be8d29766afe)|
