### PR TITLE
fix: crash when clicking on instance's emoji

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
@@ -101,7 +101,7 @@ fun HtmlText(
         val change = awaitFirstDown()
         val annotation =
           layoutResult.value?.getOffsetForPosition(change.position)?.let {
-            value.getStringAnnotations(start = it, end = it).firstOrNull()
+            value.getStringAnnotations(start = it, end = it).firstOrNull { it.item != ID_IMAGE }
           }
         annotation?.let {
           if (change.pressed != change.previousPressed) change.consume()


### PR DESCRIPTION
Clicking on mastodon instance's custom emoji will cause a crash. The reason is the emoji is also a link and it will launch chrome custom tab with `uri = "image"`.

Stack:

```
/**
 * 2024-02-22 19:25:12.153  1139-1139  AndroidRuntime          com.github.whitescent.mastify        E  FATAL EXCEPTION: main (Ask Studio Bot)
 *                                                                                                     Process: com.github.whitescent.mastify, PID: 1139
 *                                                                                                     android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat= (has extras) }
 *                                                                                                     	at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:2239)
 *                                                                                                     	at android.app.Instrumentation.execStartActivity(Instrumentation.java:1878)
 *                                                                                                     	at android.app.Activity.startActivityForResult(Activity.java:5615)
 *                                                                                                     	at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.java:780)
 *                                                                                                     	at android.app.Activity.startActivity(Activity.java:6067)
 *                                                                                                     	at androidx.core.content.ContextCompat$Api16Impl.startActivity(ContextCompat.java:1064)
 *                                                                                                     	at androidx.core.content.ContextCompat.startActivity(ContextCompat.java:322)
 *                                                                                                     	at androidx.browser.customtabs.CustomTabsIntent.launchUrl(CustomTabsIntent.java:523)
 *                                                                                                     	at com.github.whitescent.mastify.utils.LaunchCustomTabsKt.launchCustomChromeTab(launchCustomTabs.kt:34)
 *                                                                                                     	at com.github.whitescent.mastify.utils.StatusLinkHandlerKt.statusLinkHandler(statusLinkHandler.kt:43)
 *                                                                                                     	at com.github.whitescent.mastify.ui.component.status.StatusListItemKt$StatusContent$1$1$2$2$2$2$1.invoke(StatusListItem.kt:362)
 *                                                                                                     	at com.github.whitescent.mastify.ui.component.status.StatusListItemKt$StatusContent$1$1$2$2$2$2$1.invoke(StatusListItem.kt:357)
 *                                                                                                     	at com.github.whitescent.mastify.ui.component.HtmlTextKt$HtmlText$2$1$1.invokeSuspend(HtmlText.kt:112)
 *                                                                                                     	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
 *                                                                                                     	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:179)
 *                                                                                                     	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:168)
 *                                                                                                     	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:474)
 *                                                                                                     	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:508)
 *                                                                                                     	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:497)
 *                                                                                                     	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:368)
 *                                                                                                     	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:680)
 *                                                                                                     	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.dispatchPointerEvent(SuspendingPointerInputFilter.kt:559)
 *                                                                                                     	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:581)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:316)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:302)
 *                                                                                                     	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:185)
 *                                                                                                     	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:104)
 *                                                                                                     	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:113)
 *                                                                                                     	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1709)
 *                                                                                                     	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1660)
 * 2024-02-22 19:25:12.157  1139-1139  AndroidRuntime          com.github.whitescent.mastify        E  	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:1599) (Ask Studio Bot)
 *                                                                                                     	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3123)
 *                                                                                                     	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2804)
 *                                                                                                     	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3123)
 *                                                                                                     	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2804)
 *                                                                                                     	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3123)
 *                                                                                                     	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2804)
 *                                                                                                     	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3123)
 *                                                                                                     	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2804)
 *                                                                                                     	at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:490)
 *                                                                                                     	at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1904)
 *                                                                                                     	at android.app.Activity.dispatchTouchEvent(Activity.java:4403)
 *                                                                                                     	at com.android.tools.profiler.support.event.WindowProfilerCallback.dispatchTouchEvent(WindowProfilerCallback.java:69)
 *                                                                                                     	at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:448)
 *                                                                                                     	at android.view.View.dispatchPointerEvent(View.java:15928)
 *                                                                                                     	at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:7242)
 *                                                                                                     	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:7032)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:6435)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:6492)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:6458)
 *                                                                                                     	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:6623)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:6466)
 *                                                                                                     	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:6680)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:6439)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:6492)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:6458)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:6466)
 *                                                                                                     	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:6439)
 *                                                                                                     	at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:9432)
 *                                                                                                     	at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:9383)
 *                                                                                                     	at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:9352)
 *                                                                                                     	at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:9558)
 *                                                                                                     	at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:267)
 *                                                                                                     	at android.os.MessageQueue.nativePollOnce(Native Method)
 *                                                                                                     	at android.os.MessageQueue.next(MessageQueue.java:335)
 *                                                                                                     	at android.os.Looper.loopOnce(Looper.java:162)
 *                                                                                                     	at android.os.Looper.loop(Looper.java:294)
 *                                                                                                     	at android.app.ActivityThread.main(ActivityThread.java:8248)
 *                                                                                                     	at java.lang.reflect.Method.invoke(Native Method)
 *                                                                                                     	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
 *                                                                                                     	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
 *                                                                                                     	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.platform.MotionDurationScaleImpl@238801b, androidx.compose.runtime.BroadcastFrameClock@8f8f5b8, StandaloneCoroutine{Cancelling}@12edf91, AndroidUiDispatcher@4398ef6]
 *
 */

```