### PR TITLE
fix: custom emoji becomes smaller

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
@@ -134,6 +134,7 @@ fun HtmlText(
       ) { target ->
         AsyncImage(
           model = target,
+          modifier = Modifier.fillMaxSize(),
           contentDescription = null
         )
       }


### PR DESCRIPTION
Note that the first emoji becomes smaller since the second time it is rendered. I don't know why but it appears it is easier to fix. Per InlineTextContent's doc, the width and height of PlaceHolder is passed to the layout rather than the child. The [official sample](https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/InlineTextContent) also suggests adding a `fillMaxSize`.

https://github.com/whitescent/Mastify/assets/10359255/f8e27e00-a1ff-4955-b304-6c63a1af75dc

