### PR TITLE
fix: navigate to status detail when a link in notification is clicked

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/screen/notification/event/BasicEvent.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/screen/notification/event/BasicEvent.kt
@@ -164,6 +164,7 @@ fun BasicEvent(
                 maxLines = 6,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(10.dp),
+                onLinkClick = { navigateToDetail(status.actionable) },
                 filterMentionText = status.isInReplyToSomeone
               )
             }


### PR DESCRIPTION
screen record


https://github.com/whitescent/Mastify/assets/10359255/12a17e32-2ced-4a83-a1e0-c32f27a61463

