### PR TITLE
fix: rtl if the lang has a strong directional character

### DIFF
--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/HtmlText.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
@@ -79,7 +80,8 @@ fun HtmlText(
   style: TextStyle = LocalTextStyle.current.copy(
     color = color,
     fontSize = fontSize,
-    fontWeight = fontWeight
+    fontWeight = fontWeight,
+    textDirection = TextDirection.Content
   ),
   inlineContentSize: TextUnit = 20.sp,
   urlSpanStyle: SpanStyle = SpanStyle(

--- a/app/src/main/java/com/github/whitescent/mastify/ui/component/TextWithEmoji.kt
+++ b/app/src/main/java/com/github/whitescent/mastify/ui/component/TextWithEmoji.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import com.github.whitescent.mastify.mapper.toShortCode
@@ -54,7 +55,9 @@ fun TextWithEmoji(
   softWrap: Boolean = true,
   maxLines: Int = Int.MAX_VALUE,
   onTextLayout: (TextLayoutResult) -> Unit = {},
-  style: TextStyle = LocalTextStyle.current
+  style: TextStyle = LocalTextStyle.current.copy(
+    textDirection = TextDirection.Content
+  )
 ) = Text(
   text = buildAnnotatedString {
     annotateInlineEmojis(text, emojis.toShortCode())


### PR DESCRIPTION
|Before|After|
|--|--|
|![Screenshot_20240402_174045](https://github.com/whitescent/Mastify/assets/10359255/644776a0-2483-41f2-9150-93ed28193c15)|![Screenshot_20240402_173759](https://github.com/whitescent/Mastify/assets/10359255/9d5e4323-ca42-46df-bf3c-844d935c49ec)|

This probably also fixes #58 
